### PR TITLE
Proposed fix for issue #20, java.lang.ClassCastException

### DIFF
--- a/android/src/main/java/com/voximplant/foregroundservice/NotificationHelper.java
+++ b/android/src/main/java/com/voximplant/foregroundservice/NotificationHelper.java
@@ -96,7 +96,7 @@ class NotificationHelper {
             notificationBuilder = new Notification.Builder(context);
         }
 
-        int priorityInt = notificationConfig.containsKey("priority") ? notificationConfig.getInt("priority"): Notification.PRIORITY_HIGH;
+        int priorityInt = notificationConfig.containsKey("priority") ? (int)notificationConfig.getDouble("priority"): Notification.PRIORITY_HIGH;
 
         int priority;
         switch (priorityInt) {


### PR DESCRIPTION
Proposed fix for issue #20, java.lang.ClassCastException:  Double cannot be cast to java.lang.Integer

This is the proposed fix for issue #20, java.lang.ClassCastException: java.lang.Double cannot be cast to java.lang.Integer.  Line #99 of NotificationHelper.java is replaced by: int priorityInt = notificationConfig.containsKey("priority") ? (int)notificationConfig.getDouble("priority"): Notification.PRIORITY_HIGH;