### PR TITLE
fix: use FLAG_IMMUTABLE for android 12

### DIFF
--- a/android/src/main/java/com/voximplant/foregroundservice/NotificationHelper.java
+++ b/android/src/main/java/com/voximplant/foregroundservice/NotificationHelper.java
@@ -81,7 +81,8 @@ class NotificationHelper {
             return null;
         }
         Intent notificationIntent = new Intent(context, mainActivityClass);
-        PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, notificationIntent, 0);
+        PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, notificationIntent,
+                (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) ? (PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT) : PendingIntent.FLAG_UPDATE_CURRENT);
 
         Notification.Builder notificationBuilder;
 


### PR DESCRIPTION
React Native 68 でライブが開始できない不具合の修正でうｓ．
こちらの変更をfork先に適応しています

https://github.com/voximplant/react-native-foreground-service/commit/d0859795f6b548944e8259f22917d63a1758fa58

