### PR TITLE
Add TypeScript support

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "React native module to start foreground service on android",
   "main": "index.js",
   "scripts": {
+    "build": "npx -p typescript tsc --declaration --declarationDir types/ --emitDeclarationOnly --allowJs index.js"
   },
+  "typings": "types/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/voximplant/react-native-foreground-service.git"


### PR DESCRIPTION
By simply running `yarn build` or `npm run build` the type API will get updated which addresses the lack of types for those using TypeScript. It doesn't fully add types to the project but just gets rid of the 'module not found' errors one may come across when using this library.